### PR TITLE
'Undefined header.' error workaround

### DIFF
--- a/gpd3303s.py
+++ b/gpd3303s.py
@@ -59,9 +59,9 @@ class GPD3303S(object):
 
         # Check if the delimiter is properly set
         # By default, \r is the delimiter, but newer GPD3303S uses \r\n instead.
-        self.serial.setTimeout(0.1)
+        self.serial.timeout = 0.1
         ret = self.serial.read(1)
-        self.serial.setTimeout(readTimeOut)
+        self.serial.timeout = readTimeOut
         
         if ret == '\n':
             self.setDelimiter('\r\n')

--- a/gpd3303s.py
+++ b/gpd3303s.py
@@ -252,7 +252,7 @@ class GPD3303S(object):
 
         for i in range(3):
             ret = self.serial.readline(eol=self.eol)
-            print ret[:-len(self.eol)]
+            print(ret[:-len(self.eol)])
         
         err = self.getError()
         if err != 'No Error.':

--- a/gpd3303s.py
+++ b/gpd3303s.py
@@ -16,12 +16,12 @@ class MySerial(serial.Serial):
         # serial.Serial inherits serial.FileLike
         pass
     else:
-        def readline(self, eol='\r'):
+        def readline(self, eol=b'\r'):
             """
             Overrides io.RawIOBase.readline which cannot handle with '\r' delimiters
             """
             leneol = len(eol)
-            ret = ''
+            ret = b''
             while True:
                 c = self.read(1)
                 if c:
@@ -30,8 +30,7 @@ class MySerial(serial.Serial):
                         break
                 else:
                     break
-
-            return ret
+            return ret.decode()
 
 class GPD3303S(object):
     def __init__(self):
@@ -40,7 +39,7 @@ class GPD3303S(object):
         self.__dataBit = 8
         self.__stopBit = 1
         self.__dataFlowControl = None
-        self.eol = '\r'
+        self.eol = b'\r'
 
     def open(self, port, readTimeOut = 1, writeTimeOut = 1):
         self.serial = MySerial(port         = port,
@@ -68,7 +67,7 @@ class GPD3303S(object):
     def close(self):
         self.serial.close()
 
-    def setDelimiter(self, eol = '\r\n'):
+    def setDelimiter(self, eol = b'\r\n'):
         """
         Must call this method for new-firmware (2.0 or above?) instruments.
         Because the delimiter setting has been changed. 
@@ -249,7 +248,7 @@ class GPD3303S(object):
         """
         STATUS?
         """
-        self.serial.write('STATUS?\n')
+        self.serial.write(b'STATUS?\n')
 
         for i in range(3):
             ret = self.serial.readline(eol=self.eol)
@@ -293,31 +292,27 @@ class GPD3303S(object):
         SAV<NR1>
         """
         self.isValidMemory(memory)
-        self.serial.write('SAV%d\n' % memory)
-
-        err = self.getError()
-        if err != 'No Error.':
-            raise exceptions.RuntimeError(err)
+        self._setValue(b'SAV%d\n' % memory)
         
     def printHelp(self):
         """
         HELP?
         """
-        self.serial.write('HELP?\n')
+        self.serial.write(b'HELP?\n')
         
         for i in range(19):
             ret = self.serial.readline(eol=self.eol)
-            print ret[:-len(self.eol)]
+            print(ret[:-len(self.eol)])
 
         err = self.getError()
         if err != 'No Error.':
-            raise exceptions.RuntimeError(err)
+            raise RuntimeError(err)
 
     def getError(self):
         """
         ERR?
         """
-        self.serial.write('ERR?\n')
+        self.serial.write(b'ERR?\n')
         ret = self.serial.readline(eol=self.eol)
         if ret != '':
             return ret[:-len(self.eol)]

--- a/gpd3303s.py
+++ b/gpd3303s.py
@@ -3,7 +3,6 @@ This is an interface module for DC Power Supply GPD-3303S manufactured by Good
 Will Instrument Co., Ltd.
 """
 
-import exceptions
 import serial
 import sys
 
@@ -52,10 +51,10 @@ class GPD3303S(object):
                                timeout      = readTimeOut,
                                writeTimeout = writeTimeOut,
                                dsrdtr       = self.__dataFlowControl)
-        
+
         err = self.getError()
         if err != 'No Error.':
-            raise exceptions.RuntimeError(err)
+            raise RuntimeError(err)
 
         # Check if the delimiter is properly set
         # By default, \r is the delimiter, but newer GPD3303S uses \r\n instead.
@@ -82,7 +81,7 @@ class GPD3303S(object):
         are allowed.
         """
         if not (channel == 1 or channel == 2):
-            raise exceptions.RuntimeError('Invalid channel number: %d was given.' % channel)
+            raise RuntimeError('Invalid channel number: %d was given.' % channel)
 
         return True
 
@@ -92,7 +91,7 @@ class GPD3303S(object):
         are allowed.
         """
         if not (memory <= 0 or 4 < memory):
-            raise exceptions.RuntimeError('Invalid memory number: %d was given.' % memory)
+            raise RuntimeError('Invalid memory number: %d was given.' % memory)
 
         return True
 
@@ -102,7 +101,7 @@ class GPD3303S(object):
         significant figures are allowed.
         """
         if value < 0:
-            raise exceptions.RuntimeError('Invalid float value: %f was given.' % value)
+            raise RuntimeError('Invalid float value: %f was given.' % value)
         
         str = "%f" % value
         position = str.find(".")
@@ -258,7 +257,7 @@ class GPD3303S(object):
         
         err = self.getError()
         if err != 'No Error.':
-            raise exceptions.RuntimeError(err)
+            raise RuntimeError(err)
 
     def getIdentification(self):
         """
@@ -323,7 +322,7 @@ class GPD3303S(object):
         if ret != '':
             return ret[:-len(self.eol)]
         else:
-            raise exceptions.RuntimeError('Cannot read error message')
+            raise RuntimeError('Cannot read error message')
 
 
 class GPD4303S(GPD3303S):
@@ -334,7 +333,7 @@ class GPD4303S(GPD3303S):
         """
 
         if not (1 <= channel <= 4):
-            raise exceptions.RuntimeError('Invalid channel number: %d was given.' % channel)
+            raise RuntimeError('Invalid channel number: %d was given.' % channel)
         return True
 
 


### PR DESCRIPTION
Occasionally the power supply would return with an 'Undefined header.' error code, and not update the necessary variables.
Without spending too much time to investigate the underlying issue, this patch implements a simple workaround where in case of this error, the request is resent up to 20 times until either 'No error.' is reported, or a different error code is encountered.

This pull request includes some of my previous work to make the library compatible with PySerial v3 and Python 3, while maintaining backwards compatibility with Python 2.7